### PR TITLE
Add /api/results endpoint and update workout pages

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,7 +98,23 @@ bot.on("web_app_data", async (msg) => {
     bot.sendMessage(chatId, `✅ Результат для ${entry.exercise} збережено!`);
   } catch (err) {
     console.error("❌ Помилка при обробці:", err);
-    bot.sendMessage(chatId, "⚠️ Помилка при збереженні результату.");
+  bot.sendMessage(chatId, "⚠️ Помилка при збереженні результату.");
+  }
+});
+
+// 🌐 Прийом результатів напряму з WebApp
+app.post("/api/results", async (req, res) => {
+  const { userId, username, exercise, reps } = req.body;
+  if (!exercise || !Array.isArray(reps)) {
+    return res.status(400).json({ error: "invalid payload" });
+  }
+  try {
+    const entry = { userId, username, exercise, reps, date: new Date().toISOString() };
+    await collection.insertOne(entry);
+    res.json({ ok: true });
+  } catch (e) {
+    console.error("❌ Error saving results:", e);
+    res.status(500).json({ error: "DB error" });
   }
 });
 

--- a/pushups.html
+++ b/pushups.html
@@ -115,30 +115,42 @@
         }
 
         function finish() {
+            const tg = window.Telegram?.WebApp;
+            const user = tg?.initDataUnsafe?.user || {};
             const payload = {
+                userId: user.id,
+                username: user.username || user.first_name || `user${user.id}`,
                 exercise: location.pathname.includes("squats") ? "squats" : "pushups",
                 reps: repsPerSet
             };
 
-            if (window.Telegram?.WebApp) {
+            if (tg) {
                 console.log("📤 Надсилаю payload:", payload);
-                Telegram.WebApp.sendData(JSON.stringify(payload));
-                // **УВАГА**: видаляємо закриття
-                // Telegram.WebApp.close();
-
-                // Показуємо повідомлення про успіх
-                const container = document.querySelector(".container");
-                const message = document.createElement("div");
-                message.textContent = "✅ Результати збережено!";
-                message.style = `margin-top:20px; background:green; color:white; padding:12px; border:4px solid black; font-family:'Press Start 2P', cursive;`;
-                const btn = document.createElement("button");
-                btn.textContent = "🏆 Переглянути таблицю";
-                btn.className = "btn";
-                btn.style.marginTop = "12px";
-                btn.onclick = () => location.href = "scoreboard.html";
-                container.append(message, btn);
-
-                // Забираємо подвійну кнопку, якщо вдругось є
+                fetch("/api/results", {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify(payload)
+                })
+                .then(res => {
+                    if (!res.ok) throw new Error("bad status");
+                    return res.json();
+                })
+                .then(() => {
+                    const container = document.querySelector(".container");
+                    const message = document.createElement("div");
+                    message.textContent = "✅ Результати збережено!";
+                    message.style = `margin-top:20px; background:green; color:white; padding:12px; border:4px solid black; font-family:'Press Start 2P', cursive;`;
+                    const btn = document.createElement("button");
+                    btn.textContent = "🏆 Переглянути таблицю";
+                    btn.className = "btn";
+                    btn.style.marginTop = "12px";
+                    btn.onclick = () => location.href = "scoreboard.html";
+                    container.append(message, btn);
+                })
+                .catch(err => {
+                    console.error("❌ Error sending results:", err);
+                    alert("❌ Помилка відправки результатів");
+                });
             } else {
                 alert("❌ WebApp API не доступний");
             }

--- a/scoreboard.html
+++ b/scoreboard.html
@@ -91,7 +91,7 @@
   <script>
     async function loadScoreboard() {
       try {
-        const res = await fetch("https://fitness-server-8k9n.onrender.com/api/scoreboard");
+        const res = await fetch("/api/scoreboard");
         const data = await res.json();
 
         const pushups = data.pushups;

--- a/squats.html
+++ b/squats.html
@@ -115,30 +115,42 @@
         }
 
         function finish() {
+            const tg = window.Telegram?.WebApp;
+            const user = tg?.initDataUnsafe?.user || {};
             const payload = {
+                userId: user.id,
+                username: user.username || user.first_name || `user${user.id}`,
                 exercise: location.pathname.includes("squats") ? "squats" : "pushups",
                 reps: repsPerSet
             };
 
-            if (window.Telegram?.WebApp) {
+            if (tg) {
                 console.log("📤 Надсилаю payload:", payload);
-                Telegram.WebApp.sendData(JSON.stringify(payload));
-                // **УВАГА**: видаляємо закриття
-                // Telegram.WebApp.close();
-
-                // Показуємо повідомлення про успіх
-                const container = document.querySelector(".container");
-                const message = document.createElement("div");
-                message.textContent = "✅ Результати збережено!";
-                message.style = `margin-top:20px; background:green; color:white; padding:12px; border:4px solid black; font-family:'Press Start 2P', cursive;`;
-                const btn = document.createElement("button");
-                btn.textContent = "🏆 Переглянути таблицю";
-                btn.className = "btn";
-                btn.style.marginTop = "12px";
-                btn.onclick = () => location.href = "scoreboard.html";
-                container.append(message, btn);
-
-                // Забираємо подвійну кнопку, якщо вдругось є
+                fetch("/api/results", {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify(payload)
+                })
+                .then(res => {
+                    if (!res.ok) throw new Error("bad status");
+                    return res.json();
+                })
+                .then(() => {
+                    const container = document.querySelector(".container");
+                    const message = document.createElement("div");
+                    message.textContent = "✅ Результати збережено!";
+                    message.style = `margin-top:20px; background:green; color:white; padding:12px; border:4px solid black; font-family:'Press Start 2P', cursive;`;
+                    const btn = document.createElement("button");
+                    btn.textContent = "🏆 Переглянути таблицю";
+                    btn.className = "btn";
+                    btn.style.marginTop = "12px";
+                    btn.onclick = () => location.href = "scoreboard.html";
+                    container.append(message, btn);
+                })
+                .catch(err => {
+                    console.error("❌ Error sending results:", err);
+                    alert("❌ Помилка відправки результатів");
+                });
             } else {
                 alert("❌ WebApp API не доступний");
             }


### PR DESCRIPTION
## Summary
- add `/api/results` POST endpoint to store user workout data
- update pushups and squats pages to submit results via `fetch` instead of `sendData`
- keep scoreboard page fetching from the existing `/api/scoreboard` endpoint
- fix results submission URL

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68500c2192048331a524e3f69f970694